### PR TITLE
fix/rodape desatualizado

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
     </main>
     <footer>
         <section>
-        <p>&copy; 2026 Soia Cnnt. Tds s dritos rsedos.</p>
+        <p>&copy; 2026 Social Connect. Todos os direitos reservados.</p>
         </section>
         <section id="socialmedia">
             <span>xxxxx</span>


### PR DESCRIPTION
### O que foi feito
- O ano exibido no rodapé foi atualizado para o ano atual (2026).
- Os erros de digitação e letras faltando no texto descritivo do rodapé foram corrigidos.

### Por que foi feito
Para resolver os bugs de conteúdo apontados no Problema 2 da atividade, garantindo que as informações visuais da empresa estejam corretas e o layout preparado para receber os links das redes sociais na próxima etapa.

Closes #4